### PR TITLE
MTA-870 downgraded laravel cashier from version 14 to 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "doctrine/dbal": "^3.0",
     "gocustodia/laravel-10-full-calendar": "^1.0",
     "guzzlehttp/guzzle": "^7.9",
-    "laravel/cashier": "^14.14",
+    "laravel/cashier": "13.17",
     "laravel/framework": "^10.10",
     "laravel/helpers": "^1.0",
     "laravel/sanctum": "^3.3",


### PR DESCRIPTION
- MTA-870 downgraded laravel cashier from version 14 to 13